### PR TITLE
#150397729 Add Active and Inactive Tabs

### DIFF
--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -1,54 +1,138 @@
 {% load i18n staticfiles %}
+<style>
+    /* spacing between tab & content */
 
+    .tab-content>.active {
+        padding-top: 30px;
+        padding-bottom: 30px;
+    }
+
+</style>
 <link rel="stylesheet" type="text/css" href="{% static 'bower_components/datatables/media/css/dataTables.bootstrap.min.css' %}">
 <script src="{% static 'bower_components/datatables/media/js/jquery.dataTables.min.js' %}" ></script>
 <script src="{% static 'bower_components/datatables/media/js/dataTables.bootstrap.min.js' %}" ></script>
 <script>
 $(document).ready( function () {
-    /* Make table sortable */
+    /* Make tables sortable */
+
     $('#main_member_list').DataTable({
         paging: false,
         bFilter: true,
         bInfo : false
     });
+
+    $('#inactive_member_list').DataTable({
+        paging: false,
+        bFilter: true,
+        bInfo : false
+    });
+
 });
 </script>
 
-<table class="table table-hover" id="main_member_list">
-<thead>
-<tr>
-    {% for key in user_table.keys %}
-        <th>{{ key }}</th>
-    {% endfor %}
-</tr>
-</thead>
-<tbody>
-{% for current_user in user_table.users %}
-<tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
-    <td data-order="{{current_user.last_log|date:'U'}}">
-        {{current_user.last_log|default:'-/-'}}
-    </td>
-    {% if show_gym %}
-    <td>
-        {% if current_user.obj.userprofile.gym_id %}
-            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-            {{ current_user.obj.userprofile.gym }}
-            </a>
-        {% else %}
-            -/-
-        {% endif %}
-    </td>
-    {% endif %}
-</tr>
-{% endfor %}
-</tbody>
-</table>
+<div>
+    <!-- Tab Navs -->
+  <ul class="nav nav-tabs" role="tablist">
+    <li role="presentation" class="active">
+        <a href="#active_users" aria-controls="active_users" role="tab" data-toggle="tab">Active Users</a>
+    </li>
+    <li role="presentation">
+        <a href="#inactive_users" aria-controls="inactive_users" role="tab" data-toggle="tab">Inactive Users</a>
+    </li>
+  </ul>
+    <!-- Tab Content -->
+  <div class="tab-content">
+    <div role="tabpanel" class="tab-pane active" id="active_users">
+        <table class="table table-hover" id="main_member_list">
+            <thead>
+            <tr>
+                {% for key in user_table.keys %}
+                    <th>{{ key }}</th>
+                {% endfor %}
+                <th>Status</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for current_user in user_table.users %}
+            {% if current_user.obj.is_active  %}
+                <tr>
+                    <td>
+                        {{current_user.obj.pk}}
+                    </td>
+                    <td>
+                        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+                    </td>
+                    <td>
+                        {{current_user.obj.get_full_name}}
+                    </td>
+                    <td data-order="{{current_user.last_log|date:'U'}}">
+                        {{current_user.last_log|default:'-/-'}}
+                    </td>
+                    {% if show_gym %}
+                    <td>
+                        {% if current_user.obj.userprofile.gym_id %}
+                            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                            {{ current_user.obj.userprofile.gym }}
+                            </a>
+                        {% else %}
+                            -/-
+                        {% endif %}
+                    </td>
+                    {% endif %}
+                    <td>
+                        {% trans "Active" %}
+                    </td>
+                </tr>
+            {% endif %}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div role="tabpanel" class="tab-pane" id="inactive_users">
+        <table class="table table-hover" id="inactive_member_list">
+            <thead>
+            <tr>
+                {% for key in user_table.keys %}
+                    <th>{{ key }}</th>
+                {% endfor %}
+                <th>Status</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for current_user in user_table.users %}
+                {% if not current_user.obj.is_active %}
+                    <tr class="danger">
+                        <td>
+                            {{current_user.obj.pk}}
+                        </td>
+                        <td>
+                            <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+                        </td>
+                        <td>
+                            {{current_user.obj.get_full_name}}
+                        </td>
+                        <td data-order="{{current_user.last_log|date:'U'}}">
+                            {{current_user.last_log|default:'-/-'}}
+                        </td>
+                        {% if show_gym %}
+                        <td>
+                            {% if current_user.obj.userprofile.gym_id %}
+                                <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                                {{ current_user.obj.userprofile.gym }}
+                                </a>
+                            {% else %}
+                                -/-
+                            {% endif %}
+                        </td>
+                        {% endif %}
+                        <td>
+                            {% trans "Inactive" %}
+                        </td>
+                    </tr>
+                {% endif %}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+  </div>
+</div>

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -6,6 +6,9 @@
         padding-top: 30px;
         padding-bottom: 30px;
     }
+    .inactive{
+        color:red;
+    }
 
 </style>
 <link rel="stylesheet" type="text/css" href="{% static 'bower_components/datatables/media/css/dataTables.bootstrap.min.css' %}">
@@ -101,7 +104,7 @@ $(document).ready( function () {
             <tbody>
             {% for current_user in user_table.users %}
                 {% if not current_user.obj.is_active %}
-                    <tr class="danger">
+                    <tr>
                         <td>
                             {{current_user.obj.pk}}
                         </td>
@@ -125,7 +128,7 @@ $(document).ready( function () {
                             {% endif %}
                         </td>
                         {% endif %}
-                        <td>
+                        <td class="inactive">
                             {% trans "Inactive" %}
                         </td>
                     </tr>


### PR DESCRIPTION
### What does this PR do?

#### In the gym members page
- Add 2 tabs, Active Users and Inactive Users
- Add condition to check for inactive users in inactive tab
- Add datatables js for inactive user table
- Add danger class for inactive user table

### How do I manually test this?
- Login into Wger as an Administrator
- Add two or more users into the default gym(If there is a custom gym this works too)
- Click on a particular user. 
- Click on the Action on the left, then Deactivate user. When the user is deactivated, Go to the (Default) Gym section and check the Inactive Users tab

### Relevant Pivotal Tracker
[150397729](https://www.pivotaltracker.com/story/show/150397729)

### Screen Shots
<img width="755" alt="screen shot 2017-08-30 at 19 49 16" src="https://user-images.githubusercontent.com/6042152/29885383-432c67a2-8dbf-11e7-9571-7aee51ea669b.png">
-
<img width="759" alt="screen shot 2017-08-31 at 10 46 22" src="https://user-images.githubusercontent.com/6042152/29912275-cc1f5e50-8e39-11e7-83fb-06199c0bc20a.png">
