### PR TITLE
#150842089 fix landing page navigation 

### DIFF
--- a/wger/core/templates/template_features.html
+++ b/wger/core/templates/template_features.html
@@ -65,15 +65,9 @@
 
 <body id="page-top" class="index">
 
-{% if user.is_authenticated %}
-{% include 'navigation.html' %}
-{% endif  %}
-
     {% block template %}{% endblock %}
     <div id="current-url" data-current-url="{{request_full_path}}"></div>
     <div id="current-language" data-current-language="{{language.short_name}}"></div>
-
-
 
 <footer class="bg-darkest-gray">
     <div class="container">

--- a/wger/software/templates/features.html
+++ b/wger/software/templates/features.html
@@ -26,35 +26,44 @@
                     <span class="nav_text center"><strong>WGER</strong> | Workout Manager</span>
                     <ul class="nav nav-pills ml-auto">
                         <li class="nav-item">
-                                {% if not user.is_authenticated or user.userprofile.is_temporary %}
-                                {% if allow_registration %}
+                            {% if not user.is_authenticated or user.userprofile.is_temporary %}
                                     <a href="{% url 'core:user:registration' %}" class="navlinks nav-link">
                                         {% trans "Register" %}
                                     </a>
-                                {% endif %}
                             {% endif %}
                         </li>
+
+                        {% if user.is_authenticated %}
                         <li class="nav-item">
-                                {% if not user.is_authenticated or user.userprofile.is_temporary %}
-                                {% if allow_registration %}
-                                {% endif %}
-                
+                            <a href="/" class="nav-link navlinks">
+                                {% trans "Dashboard" %}
+                            </a>
+                        </li>
+                        {% endif %}
+
+                        <li class="nav-item">
+                            {% if not user.is_authenticated or user.userprofile.is_temporary %}
                                 <a href="{% url 'core:user:login' %}" class="nav-link navlinks">
                                     {% trans "Login" %}
                                 </a>
+                            {% else %}
+                                <a href="{% url 'core:user:logout' %}" class="nav-link navlinks">
+                                    {% trans "Logout" %}
+                                </a>
                             {% endif %}
-                        </li></ul>
+                        </li>
+                    </ul>
                     </nav>
 
         <div class="container">
             <div class="intro-text">
                 <div class="intro-heading">{% trans "Welcome to wger" %}</div>
                 <div class="intro-lead-in">Track your input, track your output</div>                
-                {% if allow_guest_users and not user.is_authenticated %}
                 <a href="{% url 'core:user:demo-entries' %}" class="center-block" rel="nofollow" style="margin-top: 1em;">
+                    {% if not user.is_authenticated %}
                     <div class="try_it center-block">{% trans "Try it now" %}</div>
+                    {% endif %}
                 </a>
-            {% endif %}
                 </div>
 
                 <div class="row text-center info">


### PR DESCRIPTION
#### What does this PR do?
- Remove dashboard navbar that is added to the landing page when a user is logged in
- Display the logout and dashboard button on the landing page when a user is logged in
- Hide the try it button from the landing page once a user is logged in
#### Description of Task to be completed?
- Check if a user is logged in and display appropriate buttons depending on the context
#### How should this be manually tested?
- Once a user is logged they can navigate back to the landing page by pressing back on their browser or selecting features from the "about this software" tab on the dashboard navbar 
#### What are the relevant pivotal tracker stories?
#150842089
#### Screenshots
<img width="1439" alt="screen shot 2017-09-06 at 15 49 31" src="https://user-images.githubusercontent.com/13675851/30112794-379dae12-931b-11e7-88f5-5cdf148e7cf7.png">

#### Questions: